### PR TITLE
Feature/search

### DIFF
--- a/accomodation/src/main/java/com/codecool/accommodation/AccommodationApplication.java
+++ b/accomodation/src/main/java/com/codecool/accommodation/AccommodationApplication.java
@@ -1,12 +1,7 @@
 package com.codecool.accommodation;
 
-import com.codecool.accommodation.model.entity.Accommodation;
-import com.codecool.accommodation.model.entity.Address;
-import com.codecool.accommodation.model.entity.Coordinate;
-import com.codecool.accommodation.repository.AccommodationRepository;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
-import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.netflix.eureka.EnableEurekaClient;
@@ -18,7 +13,6 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles("production")
 @RequiredArgsConstructor
 public class AccommodationApplication {
-    private final AccommodationRepository repository;
 
     public static void main(String[] args) {
         SpringApplication.run(AccommodationApplication.class, args);
@@ -28,33 +22,4 @@ public class AccommodationApplication {
     public ModelMapper mapperCreator(){
         return new ModelMapper();
     }
-
-    @Bean
-    public CommandLineRunner init() {
-        return args -> {
-            Address address = Address.builder()
-                    .city("Kazincbarcika")
-                    .street("Utca")
-                    .zipCode("4444")
-                    .houseNumber(12)
-                    .build();
-
-            Coordinate coordinate = Coordinate.builder()
-                    .latitude(22.00)
-                    .longitude(32.00)
-                    .build();
-
-            Accommodation accommodation = Accommodation.builder()
-                    .description("Nice!444négy")
-                    .maxNumberOfGuests(4000)
-                    .name("Házikó")
-                    .hostId(1L)
-                    .address(address)
-                    .coordinate(coordinate)
-                    .build();
-
-            repository.save(accommodation);
-        };
-    }
-
 }

--- a/accomodation/src/main/java/com/codecool/accommodation/AccommodationApplication.java
+++ b/accomodation/src/main/java/com/codecool/accommodation/AccommodationApplication.java
@@ -44,19 +44,13 @@ public class AccommodationApplication {
                     .longitude(32.00)
                     .build();
 
-//            Location location = Location.builder()
-//                    //.address(address)
-//                    .description("Nice!")
-//                    .coordinate(coordinate)
-//                    .build();
-
             Accommodation accommodation = Accommodation.builder()
                     .description("Nice!444négy")
-                   // .location(location)
                     .maxNumberOfGuests(4000)
                     .name("Házikó")
                     .hostId(1L)
                     .address(address)
+                    .coordinate(coordinate)
                     .build();
 
             repository.save(accommodation);

--- a/accomodation/src/main/java/com/codecool/accommodation/controller/AccommodationController.java
+++ b/accomodation/src/main/java/com/codecool/accommodation/controller/AccommodationController.java
@@ -1,7 +1,6 @@
 package com.codecool.accommodation.controller;
 
-import com.codecool.accommodation.model.DTO.AccommodationDTO;
-import com.codecool.accommodation.model.Response;
+import com.codecool.accommodation.model.DTO.NewAccommodationDTO;
 import com.codecool.accommodation.model.entity.Accommodation;
 import com.codecool.accommodation.service.AccommodationService;
 import lombok.RequiredArgsConstructor;
@@ -10,7 +9,6 @@ import org.springframework.web.bind.annotation.*;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.List;
-import java.util.NoSuchElementException;
 
 @RestController
 @RequiredArgsConstructor
@@ -39,8 +37,8 @@ public class AccommodationController {
     }
 
     @PostMapping("")
-    public void saveNewAccommodation(@RequestBody AccommodationDTO accommodationDTO) {
-        service.saveNewAccommodation(accommodationDTO);
+    public void saveNewAccommodation(@RequestBody NewAccommodationDTO newAccommodationDTO) {
+        service.saveNewAccommodation(newAccommodationDTO);
     }
 
     @DeleteMapping("/{accommodationId}")
@@ -52,8 +50,8 @@ public class AccommodationController {
     }
 
     @PutMapping("/{accommodationId}")
-    public void updateAccommodation(@PathVariable(name = "accommodationId") String accommodationId, @RequestBody AccommodationDTO accommodationDTO) {
-        service.updateAccommodation(accommodationId, accommodationDTO);
+    public void updateAccommodation(@PathVariable(name = "accommodationId") String accommodationId, @RequestBody NewAccommodationDTO newAccommodationDTO) {
+        service.updateAccommodation(accommodationId, newAccommodationDTO);
     }
 
     @GetMapping("/get-accommodation/{accommodationId}")

--- a/accomodation/src/main/java/com/codecool/accommodation/controller/AccommodationController.java
+++ b/accomodation/src/main/java/com/codecool/accommodation/controller/AccommodationController.java
@@ -16,7 +16,7 @@ public class AccommodationController {
 
     private final AccommodationService service;
 
-    @GetMapping("")
+    @GetMapping
     public List<Accommodation> getAll(){
         return service.findAll();
     }
@@ -36,7 +36,7 @@ public class AccommodationController {
         return accommodations;
     }
 
-    @PostMapping("")
+    @PostMapping
     public void saveNewAccommodation(@RequestBody NewAccommodationDTO newAccommodationDTO) {
         service.saveNewAccommodation(newAccommodationDTO);
     }

--- a/accomodation/src/main/java/com/codecool/accommodation/controller/SearchController.java
+++ b/accomodation/src/main/java/com/codecool/accommodation/controller/SearchController.java
@@ -16,7 +16,7 @@ public class SearchController {
      * TODO: make coordinates a separate class! Coordinates should always go together.
      */
 //    @GetMapping
-//    public DTOWrapper simpleSearch(
+//    public AccommodationDTOWrapper simpleSearch(
 //            @RequestParam Double longitude,
 //            @RequestParam Double latitude,
 //            @RequestParam Double radius

--- a/accomodation/src/main/java/com/codecool/accommodation/controller/SearchController.java
+++ b/accomodation/src/main/java/com/codecool/accommodation/controller/SearchController.java
@@ -1,9 +1,9 @@
 package com.codecool.accommodation.controller;
 
 import com.codecool.accommodation.model.DTO.CoordinateDTO;
-import com.codecool.accommodation.model.wrapper.AccommodationDTOWrapper;
 import com.codecool.accommodation.service.SearchService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -15,11 +15,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class SearchController {
     private final SearchService searchService;
 
-    @GetMapping
-    public AccommodationDTOWrapper simpleSearch(
+    @GetMapping(produces = "application/json;charset=utf8")
+    public ResponseEntity<?> simpleSearch(
             @RequestParam Double longitude,
             @RequestParam Double latitude,
-            @RequestParam Double radius
+            @RequestParam(required = false) Double radius
     ) {
         return searchService.getAccommodationsInRadius(new CoordinateDTO(latitude, longitude), radius);
     }

--- a/accomodation/src/main/java/com/codecool/accommodation/controller/SearchController.java
+++ b/accomodation/src/main/java/com/codecool/accommodation/controller/SearchController.java
@@ -1,8 +1,12 @@
 package com.codecool.accommodation.controller;
 
+import com.codecool.accommodation.model.DTO.CoordinateDTO;
+import com.codecool.accommodation.model.wrapper.AccommodationDTOWrapper;
 import com.codecool.accommodation.service.SearchService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -11,16 +15,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class SearchController {
     private final SearchService searchService;
 
-    /**
-     * TODO: rewrite to return wrapper class with List<SimpleSearchResultDTO> within it
-     * TODO: make coordinates a separate class! Coordinates should always go together.
-     */
-//    @GetMapping
-//    public AccommodationDTOWrapper simpleSearch(
-//            @RequestParam Double longitude,
-//            @RequestParam Double latitude,
-//            @RequestParam Double radius
-//    ) {
-//        return searchService.getAllAccommodationInRadius(new CoordinateDTO(latitude, longitude), radius);
-//    }
+    @GetMapping
+    public AccommodationDTOWrapper simpleSearch(
+            @RequestParam Double longitude,
+            @RequestParam Double latitude,
+            @RequestParam Double radius
+    ) {
+        return searchService.getAccommodationsInRadius(new CoordinateDTO(latitude, longitude), radius);
+    }
 }

--- a/accomodation/src/main/java/com/codecool/accommodation/controller/SearchController.java
+++ b/accomodation/src/main/java/com/codecool/accommodation/controller/SearchController.java
@@ -1,12 +1,8 @@
 package com.codecool.accommodation.controller;
 
-import com.codecool.accommodation.model.DTO.DTOWrapper;
-import com.codecool.accommodation.model.DTO.CoordinateDTO;
 import com.codecool.accommodation.service.SearchService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController

--- a/accomodation/src/main/java/com/codecool/accommodation/data_sample/AccommodationCreator.java
+++ b/accomodation/src/main/java/com/codecool/accommodation/data_sample/AccommodationCreator.java
@@ -1,0 +1,41 @@
+package com.codecool.accommodation.data_sample;
+
+import com.codecool.accommodation.model.entity.Accommodation;
+import com.codecool.accommodation.model.entity.Address;
+import com.codecool.accommodation.model.entity.Coordinate;
+import com.codecool.accommodation.repository.AccommodationRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AccommodationCreator {
+    private final AccommodationRepository repository;
+
+    public AccommodationCreator(AccommodationRepository repository) {
+        this.repository = repository;
+    }
+
+    public void initialize() {
+        Address address = Address.builder()
+                .city("Kazincbarcika")
+                .street("Utca")
+                .zipCode("4444")
+                .houseNumber(12)
+                .build();
+
+        Coordinate coordinate = Coordinate.builder()
+                .latitude(22.00)
+                .longitude(32.00)
+                .build();
+
+        Accommodation accommodation = Accommodation.builder()
+                .description("Nice!444négy")
+                .maxNumberOfGuests(4000)
+                .name("Házikó")
+                .hostId(1L)
+                .address(address)
+                .coordinate(coordinate)
+                .build();
+
+        repository.save(accommodation);
+    }
+}

--- a/accomodation/src/main/java/com/codecool/accommodation/data_sample/AccommodationCreator.java
+++ b/accomodation/src/main/java/com/codecool/accommodation/data_sample/AccommodationCreator.java
@@ -15,27 +15,48 @@ public class AccommodationCreator {
     }
 
     public void initialize() {
-        Address address = Address.builder()
+        NewAccommodation newAccommodation = NewAccommodation.builder()
                 .city("Kazincbarcika")
                 .street("Utca")
                 .zipCode("4444")
                 .houseNumber(12)
-                .build();
-
-        Coordinate coordinate = Coordinate.builder()
                 .latitude(22.00)
                 .longitude(32.00)
-                .build();
-
-        Accommodation accommodation = Accommodation.builder()
                 .description("Nice!444négy")
                 .maxNumberOfGuests(4000)
                 .name("Házikó")
+                .picture(null)
                 .hostId(1L)
-                .address(address)
-                .coordinate(coordinate)
                 .build();
 
+        Accommodation accommodation = createAccommodation(newAccommodation);
         repository.save(accommodation);
+    }
+
+
+    private Accommodation createAccommodation(NewAccommodation newAccommodation) {
+        Address address = Address.builder()
+                .city(newAccommodation.getCity())
+                .street(newAccommodation.getStreet())
+                .zipCode(newAccommodation.getZipCode())
+                .houseNumber(newAccommodation.getHouseNumber())
+                .build();
+
+        Coordinate coordinate = Coordinate.builder()
+                .latitude(newAccommodation.getLatitude())
+                .longitude(newAccommodation.getLongitude())
+                .build();
+
+        Accommodation accommodation = Accommodation.builder()
+                .description(newAccommodation.getDescription())
+                .maxNumberOfGuests(newAccommodation.getMaxNumberOfGuests())
+                .name(newAccommodation.getName())
+                .hostId(newAccommodation.getHostId())
+                .address(address)
+                .coordinate(coordinate)
+                .pictureUrl(newAccommodation.getPicture())
+                .build();
+
+        return accommodation;
     }
 }

--- a/accomodation/src/main/java/com/codecool/accommodation/data_sample/AccommodationCreator.java
+++ b/accomodation/src/main/java/com/codecool/accommodation/data_sample/AccommodationCreator.java
@@ -15,6 +15,118 @@ public class AccommodationCreator {
     }
 
     public void initialize() {
+        String city = "Budapest";
+        String[] zipCodes = {
+                "1137",
+                "1055",
+                "1011",
+                "1066",
+                "1074",
+                "1136",
+                "1014"
+        };
+        String[] streets = {
+                "Szent István krt.",
+                "Nagy Ignác utca",
+                "Arany János utca",
+                "Zichy Jenő utca",
+                "Dob utca",
+                "Tátra utca",
+                "Fortuna köz"
+        };
+        int[] houseNumbers = {
+                6,
+                2,
+                19,
+                19,
+                5,
+                7,
+                2
+        };
+        double[] latitudes = {
+                47.512873,
+                47.508543,
+                47.502229,
+                47.504224,
+                47.496468,
+                47.512924,
+                47.502894
+        };
+        double[] longitudes = {
+                19.049109,
+                19.052279,
+                19.050777,
+                19.056981,
+                19.059277,
+                19.050098,
+                19.031669
+        };
+        String[] descriptions = {
+                "1 guest · 1 bedroom · 1 bed · 1.5 shared bathrooms · Wifi · Kitchen · Free parking · Washing Machine",
+                "2 guest · 3 bedroom · 1 bed · 1.5 shared bathrooms · Wifi · Kitchen",
+                "4 guest · 4 bedroom · 4 bed · 2 bathrooms · Free parking · Washing Machine",
+                "1 guest · 1 bedroom · 1 bed · 1.5 shared bathrooms · Wifi · Kitchen · Free parking · Washing Machine",
+                "3 guest · 1 bedroom · 1 bed · 1.5 shared bathrooms · Wifi · Free parking · Dry Cleaning",
+                "2 guest · 1 bedroom · 1 bed · 1.5 shared bathrooms · Wifi · Washing Machine",
+                "3 guest · 1 bedroom · 1 bed · 1.5 shared bathrooms · Wifi · Kitchen · Free parking · Washing Machine"
+        };
+        int[] maxNumbersOfGuests = {
+                1,
+                2,
+                4,
+                1,
+                3,
+                2,
+                3
+        };
+        String[] names = {
+                "Stay at this spacious Edwardian House",
+                "Independant luxury studio apartment",
+                "Budapest Studio Apartments",
+                "10 mins to Deák Square",
+                "Spacious Peaceful Modern Bedroom",
+                "The Blue Room In Budapest",
+                "5 Star Luxury Apartment"
+        };
+        String[] pictureUrls = {
+                "https://encrypted-tbn0.gstatic.com/images?q=tbn%3AANd9GcQ_wbPYTxQPMcBh7SPzLFActXnP3uhifeVT_g&usqp=CAU",
+                "https://www.expatkings.com/wp-content/uploads/2018/10/Airbnb-rental-tips.-Hostmaker-1-620x349.jpg",
+                "https://www.smartertravel.com/uploads/2017/07/Untitled-design-8.jpg",
+                "https://cdn.bisnow.net/fit?height=489&type=jpeg&url=https%3A%2F%2Fs3.amazonaws.com%2Fcdn.bisnow.net%2Fcontent%2Fimages%2F2017%2F05%2F59151d0978bbf_https_press_atairbnb_com_app_uploads_2016_12_midtown_4.jpeg&width=717&sign=FeltIPi9cOWA36nVIeDvZxwgtiCZrpUyMRdvyZviTUI",
+                "https://media.cntraveler.com/photos/5a8f258bd363c34048b35aac/master/w_2250,h_1500,c_limit/airbnb-plus-london.jpg",
+                "https://static.trip101.com/paragraph_media/pictures/001/676/061/large/969ae4bb-efd1-4fb9-a4e3-5cb3316dd3c9.jpg?1562227937",
+                "https://image.insider.com/585029a0dd0895bc548b4b8b?width=750&format=jpeg&auto=webp"
+        };
+        Long[] hostIds = {
+                1L,
+                2L,
+                1L,
+                3L,
+                4L,
+                1L,
+                8L
+        };
+
+        for (int i = 0; i < descriptions.length; i++) {
+            NewAccommodation newAccommodation = NewAccommodation.builder()
+                    .city(city)
+                    .street(streets[i])
+                    .zipCode(zipCodes[i])
+                    .houseNumber(houseNumbers[i])
+                    .latitude(latitudes[i])
+                    .longitude(longitudes[i])
+                    .description(descriptions[i])
+                    .maxNumberOfGuests(maxNumbersOfGuests[i])
+                    .name(names[i])
+                    .picture(pictureUrls[i])
+                    .hostId(hostIds[i])
+                    .build();
+
+            Accommodation accommodation = createAccommodation(newAccommodation);
+            repository.saveAndFlush(accommodation);
+        }
+
+
         NewAccommodation newAccommodation = NewAccommodation.builder()
                 .city("Kazincbarcika")
                 .street("Utca")

--- a/accomodation/src/main/java/com/codecool/accommodation/data_sample/DataProvider.java
+++ b/accomodation/src/main/java/com/codecool/accommodation/data_sample/DataProvider.java
@@ -1,0 +1,18 @@
+package com.codecool.accommodation.data_sample;
+
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Service;
+
+@Service
+public class DataProvider implements CommandLineRunner {
+    private final AccommodationCreator creator;
+
+    public DataProvider(AccommodationCreator creator) {
+        this.creator = creator;
+    }
+
+    @Override
+    public void run(String... args) {
+        creator.initialize();
+    }
+}

--- a/accomodation/src/main/java/com/codecool/accommodation/data_sample/NewAccommodation.java
+++ b/accomodation/src/main/java/com/codecool/accommodation/data_sample/NewAccommodation.java
@@ -1,0 +1,20 @@
+package com.codecool.accommodation.data_sample;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+public class NewAccommodation {
+    private String city;
+    private String street;
+    private String zipCode;
+    private int houseNumber;
+    private double latitude;
+    private double longitude;
+    private String description;
+    private int maxNumberOfGuests;
+    private String name;
+    private Long hostId;
+    private String picture;
+}

--- a/accomodation/src/main/java/com/codecool/accommodation/model/DTO/AccommodationDTO.java
+++ b/accomodation/src/main/java/com/codecool/accommodation/model/DTO/AccommodationDTO.java
@@ -1,22 +1,27 @@
 package com.codecool.accommodation.model.DTO;
 
-import com.codecool.accommodation.model.entity.Coordinate;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class AccommodationDTO {
     private Long id;
     private String accommodationName;
+    private String description;
     private String pictures;
     private Integer capacity;
     private Integer numberOfRooms;
     private Integer numberOfBeds;
     private Integer numberOfBathrooms;
-    private Coordinate coordinates;
+    private CoordinateDTO coordinates;
 
-//    private String description;
+    // TODO: implement these fields later
+//    private Long hostId;
 //    private AccommodationType type;
 //    private Set<Room> rooms;
 //    private Address address;

--- a/accomodation/src/main/java/com/codecool/accommodation/model/DTO/AccommodationDTO.java
+++ b/accomodation/src/main/java/com/codecool/accommodation/model/DTO/AccommodationDTO.java
@@ -1,0 +1,23 @@
+package com.codecool.accommodation.model.DTO;
+
+import com.codecool.accommodation.model.entity.Coordinate;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class AccommodationDTO {
+    private Long id;
+    private String accommodationName;
+    private String pictures;
+    private Integer capacity;
+    private Integer numberOfRooms;
+    private Integer numberOfBeds;
+    private Integer numberOfBathrooms;
+    private Coordinate coordinates;
+
+//    private String description;
+//    private AccommodationType type;
+//    private Set<Room> rooms;
+//    private Address address;
+}

--- a/accomodation/src/main/java/com/codecool/accommodation/model/DTO/NewAccommodationDTO.java
+++ b/accomodation/src/main/java/com/codecool/accommodation/model/DTO/NewAccommodationDTO.java
@@ -11,7 +11,7 @@ import java.util.Set;
 
 @Data
 @Builder
-public class AccommodationDTO {
+public class NewAccommodationDTO {
 
     private Long hostId;
     private String name;
@@ -23,3 +23,19 @@ public class AccommodationDTO {
     private Address address;
 
 }
+/*
+Wrapper (List<AccomodationDTO>) {
+id:id,
+accommodation_name:accommodation_name
+pictures:folder_url,
+capacity:guest_number,
+number_of_rooms:number_of_rooms,
+number_of_beds:number_of_beds,
+number_of_bathrooms:number_of_bathrooms,
+coordinates:
+  {
+    latitude:latitude_coordinate,
+    longitude:longitude_coordinate
+  }
+}
+ */

--- a/accomodation/src/main/java/com/codecool/accommodation/model/DTO/NewAccommodationDTO.java
+++ b/accomodation/src/main/java/com/codecool/accommodation/model/DTO/NewAccommodationDTO.java
@@ -23,19 +23,3 @@ public class NewAccommodationDTO {
     private Address address;
 
 }
-/*
-Wrapper (List<AccomodationDTO>) {
-id:id,
-accommodation_name:accommodation_name
-pictures:folder_url,
-capacity:guest_number,
-number_of_rooms:number_of_rooms,
-number_of_beds:number_of_beds,
-number_of_bathrooms:number_of_bathrooms,
-coordinates:
-  {
-    latitude:latitude_coordinate,
-    longitude:longitude_coordinate
-  }
-}
- */

--- a/accomodation/src/main/java/com/codecool/accommodation/model/entity/Accommodation.java
+++ b/accomodation/src/main/java/com/codecool/accommodation/model/entity/Accommodation.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import lombok.*;
+import org.hibernate.annotations.Type;
+
 import javax.persistence.*;
 import java.util.HashSet;
 import java.util.Set;
@@ -29,6 +31,8 @@ public class Accommodation {
     @Column
     private String description;
 
+    @Lob
+    @Type(type = "org.hibernate.type.TextType")
     private String pictureUrl;
 
     @Column(nullable = false)

--- a/accomodation/src/main/java/com/codecool/accommodation/model/wrapper/AccommodationDTOWrapper.java
+++ b/accomodation/src/main/java/com/codecool/accommodation/model/wrapper/AccommodationDTOWrapper.java
@@ -1,6 +1,6 @@
 package com.codecool.accommodation.model.wrapper;
 
-import com.codecool.accommodation.model.DTO.AccommodationDTO;
+import com.codecool.accommodation.model.DTO.NewAccommodationDTO;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
@@ -10,5 +10,5 @@ import java.util.List;
 @AllArgsConstructor
 public class AccommodationDTOWrapper {
 
-    private List<AccommodationDTO> accommodationDTOS;
+    private List<NewAccommodationDTO> newAccommodationDTOS;
 }

--- a/accomodation/src/main/java/com/codecool/accommodation/model/wrapper/AccommodationDTOWrapper.java
+++ b/accomodation/src/main/java/com/codecool/accommodation/model/wrapper/AccommodationDTOWrapper.java
@@ -9,5 +9,5 @@ import java.util.List;
 @Data
 @AllArgsConstructor
 public class AccommodationDTOWrapper {
-    private List<AccommodationDTO> AccommodationDTOS;
+    private List<AccommodationDTO> AccommodationDTO;
 }

--- a/accomodation/src/main/java/com/codecool/accommodation/model/wrapper/AccommodationDTOWrapper.java
+++ b/accomodation/src/main/java/com/codecool/accommodation/model/wrapper/AccommodationDTOWrapper.java
@@ -1,5 +1,6 @@
-package com.codecool.accommodation.model.DTO;
+package com.codecool.accommodation.model.wrapper;
 
+import com.codecool.accommodation.model.DTO.AccommodationDTO;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
@@ -7,7 +8,7 @@ import java.util.List;
 
 @Data
 @AllArgsConstructor
-public class DTOWrapper {
+public class AccommodationDTOWrapper {
 
     private List<AccommodationDTO> accommodationDTOS;
 }

--- a/accomodation/src/main/java/com/codecool/accommodation/model/wrapper/AccommodationDTOWrapper.java
+++ b/accomodation/src/main/java/com/codecool/accommodation/model/wrapper/AccommodationDTOWrapper.java
@@ -1,6 +1,6 @@
 package com.codecool.accommodation.model.wrapper;
 
-import com.codecool.accommodation.model.DTO.NewAccommodationDTO;
+import com.codecool.accommodation.model.DTO.AccommodationDTO;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
@@ -9,6 +9,5 @@ import java.util.List;
 @Data
 @AllArgsConstructor
 public class AccommodationDTOWrapper {
-
-    private List<NewAccommodationDTO> newAccommodationDTOS;
+    private List<AccommodationDTO> AccommodationDTOS;
 }

--- a/accomodation/src/main/java/com/codecool/accommodation/model/wrapper/NewAccommodationDTOWrapper.java
+++ b/accomodation/src/main/java/com/codecool/accommodation/model/wrapper/NewAccommodationDTOWrapper.java
@@ -1,0 +1,14 @@
+package com.codecool.accommodation.model.wrapper;
+
+import com.codecool.accommodation.model.DTO.NewAccommodationDTO;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class NewAccommodationDTOWrapper {
+
+    private List<NewAccommodationDTO> newAccommodationDTOS;
+}

--- a/accomodation/src/main/java/com/codecool/accommodation/service/AccommodationService.java
+++ b/accomodation/src/main/java/com/codecool/accommodation/service/AccommodationService.java
@@ -1,7 +1,6 @@
 package com.codecool.accommodation.service;
 
-import com.codecool.accommodation.model.DTO.AccommodationDTO;
-import com.codecool.accommodation.model.DTO.RoomDTO;
+import com.codecool.accommodation.model.DTO.NewAccommodationDTO;
 import com.codecool.accommodation.model.entity.Accommodation;
 import com.codecool.accommodation.service.DAO.AccommodationDAO;
 import com.codecool.accommodation.service.DAO.RoomDAO;
@@ -24,13 +23,13 @@ public class AccommodationService {
         return accommodationDAO.findAllByHostId(hostId);
     }
 
-    public Response saveNewAccommodation(AccommodationDTO accommodationDTO) {
+    public Response saveNewAccommodation(NewAccommodationDTO newAccommodationDTO) {
         try {
-            if (accommodationDTO.getHostId() != null ||
-                accommodationDTO.getName() != null ||
-                accommodationDTO.getMaxNumberOfGuest() != null) {
+            if (newAccommodationDTO.getHostId() != null ||
+                newAccommodationDTO.getName() != null ||
+                newAccommodationDTO.getMaxNumberOfGuest() != null) {
 
-                accommodationDAO.saveNewAccommodation(accommodationDTO);
+                accommodationDAO.saveNewAccommodation(newAccommodationDTO);
 
 
                 return new Response(true, "SUCCESS");
@@ -59,9 +58,9 @@ public class AccommodationService {
 
     }
 
-    public void updateAccommodation(String accommodationId, AccommodationDTO accommodationDTO) {
+    public void updateAccommodation(String accommodationId, NewAccommodationDTO newAccommodationDTO) {
         try {
-            accommodationDAO.updateAccommodation(Long.parseLong(accommodationId), accommodationDTO);
+            accommodationDAO.updateAccommodation(Long.parseLong(accommodationId), newAccommodationDTO);
         } catch (NullArgumentException exception) {
             exception.printStackTrace();
         }

--- a/accomodation/src/main/java/com/codecool/accommodation/service/DAO/AccommodationDAO.java
+++ b/accomodation/src/main/java/com/codecool/accommodation/service/DAO/AccommodationDAO.java
@@ -1,6 +1,6 @@
 package com.codecool.accommodation.service.DAO;
 
-import com.codecool.accommodation.model.DTO.AccommodationDTO;
+import com.codecool.accommodation.model.DTO.NewAccommodationDTO;
 import com.codecool.accommodation.model.entity.Accommodation;
 
 import java.util.List;
@@ -9,9 +9,9 @@ public interface AccommodationDAO {
 
     List<Accommodation> findAll();
     List<Accommodation> findAllByHostId(Long hostId);
-    void saveNewAccommodation(AccommodationDTO accommodationDTO);
+    void saveNewAccommodation(NewAccommodationDTO newAccommodationDTO);
     void deleteAccommodation(Long accommodationId);
     Accommodation findAccommodationById(Long accommodationId);
-    void updateAccommodation(Long accommodationId, AccommodationDTO accommodationDTO);
+    void updateAccommodation(Long accommodationId, NewAccommodationDTO newAccommodationDTO);
     boolean isExisted(Long accommodationId);
 }

--- a/accomodation/src/main/java/com/codecool/accommodation/service/DAO/AccommodationDB.java
+++ b/accomodation/src/main/java/com/codecool/accommodation/service/DAO/AccommodationDB.java
@@ -1,22 +1,18 @@
 package com.codecool.accommodation.service.DAO;
 
-import com.codecool.accommodation.model.DTO.AccommodationDTO;
-import com.codecool.accommodation.model.DTO.RoomDTO;
+import com.codecool.accommodation.model.DTO.NewAccommodationDTO;
 import com.codecool.accommodation.model.entity.*;
 import com.codecool.accommodation.repository.AccommodationRepository;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.Session;
-import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
 import org.springframework.stereotype.Component;
 
 import javax.persistence.*;
 import javax.transaction.Transactional;
 import java.util.List;
-import java.util.NoSuchElementException;
-import java.util.Set;
 
 @Component
 @Data
@@ -42,19 +38,19 @@ public class AccommodationDB implements AccommodationDAO {
 
     //@Transactional
     @Override
-    public void saveNewAccommodation(AccommodationDTO accommodationDTO) {
+    public void saveNewAccommodation(NewAccommodationDTO newAccommodationDTO) {
 
-        Coordinate coordinate = new Coordinate(accommodationDTO.getCoordinate().getLongitude(), accommodationDTO.getCoordinate().getLatitude());
+        Coordinate coordinate = new Coordinate(newAccommodationDTO.getCoordinate().getLongitude(), newAccommodationDTO.getCoordinate().getLatitude());
 
-        Address address = accommodationDTO.getAddress();
+        Address address = newAccommodationDTO.getAddress();
         //Location location = accommodationDTO.getLocation();
 
         Accommodation accommodation2 = new Accommodation();
-        accommodation2.setDescription(accommodationDTO.getDescription());
-        accommodation2.setHostId(accommodationDTO.getHostId());
-        accommodation2.setMaxNumberOfGuests(accommodationDTO.getMaxNumberOfGuest());
-        accommodation2.setName(accommodationDTO.getName());
-        accommodation2.setType(accommodationDTO.getType());
+        accommodation2.setDescription(newAccommodationDTO.getDescription());
+        accommodation2.setHostId(newAccommodationDTO.getHostId());
+        accommodation2.setMaxNumberOfGuests(newAccommodationDTO.getMaxNumberOfGuest());
+        accommodation2.setName(newAccommodationDTO.getName());
+        accommodation2.setType(newAccommodationDTO.getType());
         accommodation2.setAddress(address);
         accommodation2.setCoordinate(coordinate);
         //accommodation2.setLocation(location);
@@ -63,7 +59,7 @@ public class AccommodationDB implements AccommodationDAO {
         Session session = entityManager.unwrap(Session.class);
         Transaction tx = session.beginTransaction();
 
-        for(Room room : accommodationDTO.getRooms()){
+        for(Room room : newAccommodationDTO.getRooms()){
             if(accommodation2.getRooms()== null){
                 accommodation2.createRooms();
             }
@@ -99,12 +95,12 @@ public class AccommodationDB implements AccommodationDAO {
 
     @Override
     @Transactional
-    public void updateAccommodation(Long accommodationId, AccommodationDTO accommodationDTO) {
+    public void updateAccommodation(Long accommodationId, NewAccommodationDTO newAccommodationDTO) {
         Accommodation toEdit = findAccommodationById(accommodationId);
 
-        toEdit.setName(accommodationDTO.getName());
-        toEdit.setDescription(accommodationDTO.getDescription());
-        toEdit.setMaxNumberOfGuests(accommodationDTO.getMaxNumberOfGuest());
+        toEdit.setName(newAccommodationDTO.getName());
+        toEdit.setDescription(newAccommodationDTO.getDescription());
+        toEdit.setMaxNumberOfGuests(newAccommodationDTO.getMaxNumberOfGuest());
 
         //toEdit.setRooms(accommodationDTO.getRooms());
         repository.save(toEdit);

--- a/accomodation/src/main/java/com/codecool/accommodation/service/DAO/RoomDAO.java
+++ b/accomodation/src/main/java/com/codecool/accommodation/service/DAO/RoomDAO.java
@@ -1,9 +1,9 @@
 package com.codecool.accommodation.service.DAO;
 
-import com.codecool.accommodation.model.DTO.AccommodationDTO;
+import com.codecool.accommodation.model.DTO.NewAccommodationDTO;
 import com.codecool.accommodation.model.DTO.RoomDTO;
 
 public interface RoomDAO {
     void saveNewRoom(RoomDTO roomDTO, Long accommodationId);
-    void saveNewRoom(RoomDTO roomDTO, AccommodationDTO accommodationDTO);
+    void saveNewRoom(RoomDTO roomDTO, NewAccommodationDTO newAccommodationDTO);
 }

--- a/accomodation/src/main/java/com/codecool/accommodation/service/DAO/RoomDB.java
+++ b/accomodation/src/main/java/com/codecool/accommodation/service/DAO/RoomDB.java
@@ -1,6 +1,6 @@
 package com.codecool.accommodation.service.DAO;
 
-import com.codecool.accommodation.model.DTO.AccommodationDTO;
+import com.codecool.accommodation.model.DTO.NewAccommodationDTO;
 import com.codecool.accommodation.model.DTO.RoomDTO;
 import com.codecool.accommodation.model.entity.Accommodation;
 import com.codecool.accommodation.model.entity.Room;
@@ -29,7 +29,7 @@ public class RoomDB implements RoomDAO{
     }
 
     @Override
-    public void saveNewRoom(RoomDTO roomDTO, AccommodationDTO accommodationDTO) {
+    public void saveNewRoom(RoomDTO roomDTO, NewAccommodationDTO newAccommodationDTO) {
 
     }
 }

--- a/accomodation/src/main/java/com/codecool/accommodation/service/DTOCreator.java
+++ b/accomodation/src/main/java/com/codecool/accommodation/service/DTOCreator.java
@@ -1,6 +1,6 @@
 package com.codecool.accommodation.service;
 
-import com.codecool.accommodation.model.DTO.AccommodationDTO;
+import com.codecool.accommodation.model.DTO.NewAccommodationDTO;
 import com.codecool.accommodation.model.wrapper.AccommodationDTOWrapper;
 import com.codecool.accommodation.model.entity.Accommodation;
 import lombok.RequiredArgsConstructor;
@@ -26,9 +26,9 @@ public class DTOCreator {
                         .collect(Collectors.toList()));
     }
 
-    private AccommodationDTO converter(Accommodation accommodation) {
+    private NewAccommodationDTO converter(Accommodation accommodation) {
         modelMapper.getConfiguration()
                 .setMatchingStrategy(MatchingStrategies.LOOSE);
-        return modelMapper.map(accommodation, AccommodationDTO.class);
+        return modelMapper.map(accommodation, NewAccommodationDTO.class);
     }
 }

--- a/accomodation/src/main/java/com/codecool/accommodation/service/DTOCreator.java
+++ b/accomodation/src/main/java/com/codecool/accommodation/service/DTOCreator.java
@@ -52,7 +52,7 @@ public class DTOCreator {
                 .accommodationName(accommodation.getName())
                 .description(accommodation.getDescription())
                 .pictures(accommodation.getPictureUrl())
-//                .capacity() // TODO: implement calculate capacity
+                .capacity(accommodation.getMaxNumberOfGuests()) // TODO: implement calculate capacity
                 .numberOfRooms(accommodation.getRooms().size())
 //                .numberOfBeds() // TODO: implement calculate number of beds
 //                .numberOfBathrooms() // TODO: implement caclulate number of bathrooms

--- a/accomodation/src/main/java/com/codecool/accommodation/service/DTOCreator.java
+++ b/accomodation/src/main/java/com/codecool/accommodation/service/DTOCreator.java
@@ -1,7 +1,7 @@
 package com.codecool.accommodation.service;
 
 import com.codecool.accommodation.model.DTO.AccommodationDTO;
-import com.codecool.accommodation.model.DTO.DTOWrapper;
+import com.codecool.accommodation.model.wrapper.AccommodationDTOWrapper;
 import com.codecool.accommodation.model.entity.Accommodation;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
@@ -18,8 +18,8 @@ public class DTOCreator {
     private final ModelMapper modelMapper;
 
 
-    public DTOWrapper turnInputListToDTO(List<Accommodation> accommodations) {
-        return new DTOWrapper(
+    public AccommodationDTOWrapper turnInputListToDTO(List<Accommodation> accommodations) {
+        return new AccommodationDTOWrapper(
                 accommodations
                         .stream()
                         .map(this::converter)

--- a/accomodation/src/main/java/com/codecool/accommodation/service/DTOCreator.java
+++ b/accomodation/src/main/java/com/codecool/accommodation/service/DTOCreator.java
@@ -1,6 +1,9 @@
 package com.codecool.accommodation.service;
 
+import com.codecool.accommodation.model.DTO.AccommodationDTO;
+import com.codecool.accommodation.model.DTO.CoordinateDTO;
 import com.codecool.accommodation.model.DTO.NewAccommodationDTO;
+import com.codecool.accommodation.model.wrapper.AccommodationDTOWrapper;
 import com.codecool.accommodation.model.wrapper.NewAccommodationDTOWrapper;
 import com.codecool.accommodation.model.entity.Accommodation;
 import lombok.RequiredArgsConstructor;
@@ -17,18 +20,40 @@ public class DTOCreator {
 
     private final ModelMapper modelMapper;
 
-
-    public NewAccommodationDTOWrapper turnInputListToDTO(List<Accommodation> accommodations) {
+    public NewAccommodationDTOWrapper turnInputListToNewAccommodationDTO(List<Accommodation> accommodations) {
         return new NewAccommodationDTOWrapper(
                 accommodations
                         .stream()
-                        .map(this::converter)
+                        .map(this::convertToNewAccommodationDTO)
                         .collect(Collectors.toList()));
     }
 
-    private NewAccommodationDTO converter(Accommodation accommodation) {
+    public AccommodationDTOWrapper turnInputListToAccommodationDTO(List<Accommodation> accommodations) {
+        return new AccommodationDTOWrapper(
+                accommodations
+                        .stream()
+                        .map(this::convertToAccommodationDTO)
+                        .collect(Collectors.toList()));
+    }
+
+    private NewAccommodationDTO convertToNewAccommodationDTO(Accommodation accommodation) {
         modelMapper.getConfiguration()
                 .setMatchingStrategy(MatchingStrategies.LOOSE);
         return modelMapper.map(accommodation, NewAccommodationDTO.class);
+    }
+
+    private AccommodationDTO convertToAccommodationDTO(Accommodation accommodation) {
+        return AccommodationDTO.builder()
+                .id(accommodation.getId())
+                .accommodationName(accommodation.getName())
+                .description(accommodation.getDescription())
+                .pictures(accommodation.getPictureUrl())
+//                .capacity() // TODO: implement calculate capacity
+                .numberOfRooms(accommodation.getRooms().size())
+//                .numberOfBeds() // TODO: implement calculate number of beds
+//                .numberOfBathrooms() // TODO: implement caclulate number of bathrooms
+                .coordinates(new CoordinateDTO(accommodation.getCoordinate().getLatitude(), accommodation.getCoordinate().getLongitude()))
+                .build();
+
     }
 }

--- a/accomodation/src/main/java/com/codecool/accommodation/service/DTOCreator.java
+++ b/accomodation/src/main/java/com/codecool/accommodation/service/DTOCreator.java
@@ -43,6 +43,10 @@ public class DTOCreator {
     }
 
     private AccommodationDTO convertToAccommodationDTO(Accommodation accommodation) {
+        CoordinateDTO coordinateDTO = (accommodation.getCoordinate() == null)
+                ? new CoordinateDTO(null, null)
+                : new CoordinateDTO(accommodation.getCoordinate().getLatitude(), accommodation.getCoordinate().getLongitude());
+
         return AccommodationDTO.builder()
                 .id(accommodation.getId())
                 .accommodationName(accommodation.getName())
@@ -52,7 +56,7 @@ public class DTOCreator {
                 .numberOfRooms(accommodation.getRooms().size())
 //                .numberOfBeds() // TODO: implement calculate number of beds
 //                .numberOfBathrooms() // TODO: implement caclulate number of bathrooms
-                .coordinates(new CoordinateDTO(accommodation.getCoordinate().getLatitude(), accommodation.getCoordinate().getLongitude()))
+                .coordinates(coordinateDTO)
                 .build();
 
     }

--- a/accomodation/src/main/java/com/codecool/accommodation/service/DTOCreator.java
+++ b/accomodation/src/main/java/com/codecool/accommodation/service/DTOCreator.java
@@ -1,7 +1,7 @@
 package com.codecool.accommodation.service;
 
 import com.codecool.accommodation.model.DTO.NewAccommodationDTO;
-import com.codecool.accommodation.model.wrapper.AccommodationDTOWrapper;
+import com.codecool.accommodation.model.wrapper.NewAccommodationDTOWrapper;
 import com.codecool.accommodation.model.entity.Accommodation;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
@@ -18,8 +18,8 @@ public class DTOCreator {
     private final ModelMapper modelMapper;
 
 
-    public AccommodationDTOWrapper turnInputListToDTO(List<Accommodation> accommodations) {
-        return new AccommodationDTOWrapper(
+    public NewAccommodationDTOWrapper turnInputListToDTO(List<Accommodation> accommodations) {
+        return new NewAccommodationDTOWrapper(
                 accommodations
                         .stream()
                         .map(this::converter)

--- a/accomodation/src/main/java/com/codecool/accommodation/service/SearchService.java
+++ b/accomodation/src/main/java/com/codecool/accommodation/service/SearchService.java
@@ -1,16 +1,7 @@
 package com.codecool.accommodation.service;
 
-import com.codecool.accommodation.model.DTO.CoordinateDTO;
-import com.codecool.accommodation.model.DTO.DTOWrapper;
-import com.codecool.accommodation.model.entity.Accommodation;
-import com.codecool.accommodation.model.entity.Coordinate;
-import com.codecool.accommodation.service.DAO.CoordinateDAO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor

--- a/accomodation/src/main/java/com/codecool/accommodation/service/SearchService.java
+++ b/accomodation/src/main/java/com/codecool/accommodation/service/SearchService.java
@@ -1,17 +1,14 @@
 package com.codecool.accommodation.service;
 
-import com.codecool.accommodation.model.DTO.AccommodationDTO;
 import com.codecool.accommodation.model.DTO.CoordinateDTO;
 import com.codecool.accommodation.model.entity.Accommodation;
 import com.codecool.accommodation.model.entity.Coordinate;
-import com.codecool.accommodation.model.wrapper.AccommodationDTOWrapper;
 import com.codecool.accommodation.service.DAO.CoordinateDAO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 @Service
@@ -19,25 +16,20 @@ import java.util.List;
 public class SearchService {
     private final DTOCreator creator;
     private final CoordinateDAO coordinateDAO;
+    private static final double DEFAULT_SEARCH_DISTANCE = 0D;
+    private static final String NO_COORDINATE_MESSAGE = "Coordinates cannot be null.";
 
     public ResponseEntity<?> getAccommodationsInRadius(CoordinateDTO coordinate, Double searchRadius) {
-        searchRadius = searchRadius == null ? 0D : searchRadius;
+        searchRadius = searchRadius == null ? DEFAULT_SEARCH_DISTANCE : searchRadius;
         if (coordinate.getLatitude() == null || coordinate.getLongitude() == null)
-            return ResponseEntity.status(400).body("Coordinates cannot be null.");
-
-        List<Coordinate> foundCoordinates = coordinateDAO.getAllByDistanceFromCoordinate(coordinate, searchRadius);
-        if (foundCoordinates.isEmpty())
-            return ResponseEntity.ok(
-                    new AccommodationDTOWrapper(Collections.singletonList(
-                            AccommodationDTO.builder()
-                                    .coordinates(new CoordinateDTO(null, null))
-                                    .build())
-                    )
-            );
+            return ResponseEntity.status(400).body(NO_COORDINATE_MESSAGE);
 
         List<Accommodation> allAccommodationsInRadius = new ArrayList<>();
-        for (Coordinate actualCoordinate : foundCoordinates) {
-            allAccommodationsInRadius.add(actualCoordinate.getAccommodation());
+        List<Coordinate> foundCoordinates = coordinateDAO.getAllByDistanceFromCoordinate(coordinate, searchRadius);
+        if (!foundCoordinates.isEmpty()) {
+            for (Coordinate actualCoordinate : foundCoordinates) {
+                allAccommodationsInRadius.add(actualCoordinate.getAccommodation());
+            }
         }
         return ResponseEntity.ok(creator.turnInputListToAccommodationDTO(allAccommodationsInRadius));
     }

--- a/accomodation/src/main/java/com/codecool/accommodation/service/SearchService.java
+++ b/accomodation/src/main/java/com/codecool/accommodation/service/SearchService.java
@@ -1,28 +1,40 @@
 package com.codecool.accommodation.service;
 
+import com.codecool.accommodation.model.DTO.AccommodationDTO;
+import com.codecool.accommodation.model.DTO.CoordinateDTO;
+import com.codecool.accommodation.model.entity.Accommodation;
+import com.codecool.accommodation.model.entity.Coordinate;
+import com.codecool.accommodation.model.wrapper.AccommodationDTOWrapper;
+import com.codecool.accommodation.service.DAO.CoordinateDAO;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class SearchService {
-//    private final DTOCreator creator;
-//    private final CoordinateDAO coordinateDAO;
-//    private final LocationDAO locationDAO;
-//
-//    public DTOWrapper getAllAccommodationInRadius(CoordinateDTO coordinate, Double searchRadius) {
-//        List<Coordinate> coordinatesWithinDistance = coordinateDAO.getAllByDistanceFromCoordinate(coordinate, searchRadius);
-//        if (coordinatesWithinDistance.isEmpty()) return creator.turnInputListToDTO(Arrays.asList(new Accommodation()));
-//
-//        List<Accommodation> allAccommodationsInRadius = new ArrayList<>();
-//        System.out.println(coordinatesWithinDistance);
-//        for (Coordinate actualCoordinate : coordinatesWithinDistance) {
-//            Location actualLocation = locationDAO.getLocationByCoordinate(actualCoordinate);
-//
-//            allAccommodationsInRadius.add(actualLocation.getAccommodation());
-//        }
-//        return creator.turnInputListToDTO(allAccommodationsInRadius);
-//    }
+    private final DTOCreator creator;
+    private final CoordinateDAO coordinateDAO;
 
+    public ResponseEntity<?> getAccommodationsInRadius(CoordinateDTO coordinate, Double searchRadius) {
+        List<Coordinate> foundCoordinates = coordinateDAO.getAllByDistanceFromCoordinate(coordinate, searchRadius);
+        if (foundCoordinates.isEmpty())
+            return ResponseEntity.ok(
+                    new AccommodationDTOWrapper(Collections.singletonList(
+                            AccommodationDTO.builder()
+                                    .coordinates(new CoordinateDTO(null, null))
+                                    .build())
+                    )
+            );
 
+        List<Accommodation> allAccommodationsInRadius = new ArrayList<>();
+        for (Coordinate actualCoordinate : foundCoordinates) {
+            allAccommodationsInRadius.add(actualCoordinate.getAccommodation());
+        }
+        return ResponseEntity.ok(creator.turnInputListToAccommodationDTO(allAccommodationsInRadius));
+    }
 }

--- a/accomodation/src/main/java/com/codecool/accommodation/service/SearchService.java
+++ b/accomodation/src/main/java/com/codecool/accommodation/service/SearchService.java
@@ -21,6 +21,10 @@ public class SearchService {
     private final CoordinateDAO coordinateDAO;
 
     public ResponseEntity<?> getAccommodationsInRadius(CoordinateDTO coordinate, Double searchRadius) {
+        searchRadius = searchRadius == null ? 0D : searchRadius;
+        if (coordinate.getLatitude() == null || coordinate.getLongitude() == null)
+            return ResponseEntity.status(400).body("Coordinates cannot be null.");
+
         List<Coordinate> foundCoordinates = coordinateDAO.getAllByDistanceFromCoordinate(coordinate, searchRadius);
         if (foundCoordinates.isEmpty())
             return ResponseEntity.ok(


### PR DESCRIPTION
Add simple search feature and endpoint for accommodation. Takes a set of coordinates and a(n optional) search radius/distance.

For details on the endpoint see the API documentation.

Please note that former AccommodationDTO is renamed to NewAccommodationDTO as it acts as such.

Also note that ordering, filtering and limiting the search results is not yet implemented. Works through gateway. Test with dummy data (finds accommodation): `http://localhost:8762/acc/search?latitude=22&longitude=32&radius=2`
